### PR TITLE
Improve Landing Guidance

### DIFF
--- a/MechJeb2/MechJebModuleLandingGuidance.cs
+++ b/MechJeb2/MechJebModuleLandingGuidance.cs
@@ -396,7 +396,7 @@ namespace MuMech
                 }
             }
 
-            if (_landingSiteIdx > LandingSites.Count)
+            if (_landingSiteIdx < 0 || _landingSiteIdx >= LandingSites.Count)
             {
                 _landingSiteIdx = 0;
             }


### PR DESCRIPTION
## Summary
- guard against invalid landing site index in landing guidance

## Testing
- `make build` *(fails: resgen2: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e59cc91883308d9a8083d637294b